### PR TITLE
Video/Null State Copy

### DIFF
--- a/app/src/main/java/com/tangxiaolv/telegramgallery/app/MainActivity.java
+++ b/app/src/main/java/com/tangxiaolv/telegramgallery/app/MainActivity.java
@@ -32,6 +32,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
         Button btn = (Button) findViewById(R.id.btn);
         Button btn2 = (Button) findViewById(R.id.btn2);
+        Button btn3 = (Button) findViewById(R.id.btn3);
         GridView gv = (GridView) findViewById(R.id.gv);
         gv.setAdapter(adapter = new BaseAdapter() {
             @Override
@@ -73,20 +74,31 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 GalleryConfig config = new GalleryConfig.Build()
-                        .limitPickPhoto(11)
-                        .singleEntity(false)
-                        .hintOfPick("this is pick hint")
-                        .filterMimeTypes(new String[]{})
-                        .build();
+                    .limitPickPhoto(10)
+                    .singleEntity(false)
+                    .pickerMode(GalleryConfig.PHOTO_MODE)
+                    .hintOfPick("this is pick hint")
+                    .build();
                 GalleryActivity.openActivity(MainActivity.this, reqCode, config);
             }
         });
-
         btn2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 GalleryConfig config = new GalleryConfig.Build()
-                        .singleEntity(true).build();
+                    .singleEntity(true)
+                    .pickerMode(GalleryConfig.PHOTO_MODE)
+                    .build();
+                GalleryActivity.openActivity(MainActivity.this, reqCode, config);
+            }
+        });
+        btn3.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                GalleryConfig config = new GalleryConfig.Build()
+                    .singleEntity(true)
+                    .pickerMode(GalleryConfig.VIDEO_MODE)
+                    .build();
                 GalleryActivity.openActivity(MainActivity.this, reqCode, config);
             }
         });

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -13,13 +13,19 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:text="相册多选"/>
+        android:text="@string/pick_up_to_10_photos"/>
     <Button
         android:id="@+id/btn2"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:text="相册单选"/>
+        android:text="@string/pick_single_photo"/>
+    <Button
+        android:id="@+id/btn3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/pick_single_video"/>
 
 
     <GridView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">TelegramGallery</string>
+    <string name="pick_up_to_10_photos">Pick up to 10 photos</string>
+    <string name="pick_single_photo">Pick a single photo</string>
+    <string name="pick_single_video">Pick a single video</string>
 </resources>

--- a/telegramgallery/src/main/java/com/tangxiaolv/telegramgallery/GalleryConfig.java
+++ b/telegramgallery/src/main/java/com/tangxiaolv/telegramgallery/GalleryConfig.java
@@ -76,6 +76,7 @@ public class GalleryConfig implements Parcelable {
         private int limitPickPhoto = 9;
         private PendingIntent multiPhotoSelectedPendingIntent = null;
         private @PickerMode int pickerMode = PHOTO_MODE;
+        private boolean hasModeBeenSet = false;
 
         /**
          * @param filterMimeTypes filter of media type， based on MimeType standards：
@@ -84,6 +85,9 @@ public class GalleryConfig implements Parcelable {
          */
         public Build filterMimeTypes(String[] filterMimeTypes) {
             this.filterMimeTypes = filterMimeTypes;
+            if (this.hasModeBeenSet) {
+                throw new IllegalStateException("filterMimeTypes() is not compatible with pickerMode()");
+            }
             return this;
         }
 
@@ -123,8 +127,17 @@ public class GalleryConfig implements Parcelable {
             return this;
         }
 
+        /**
+         * @param pickerMode the mode of the picker, one of PHOTO_MODE or VIDEO_MODE.
+         *                   Setting this mode will override anything passed via
+         *                   {@code filterMimeTypes}
+         */
         public Build pickerMode(@PickerMode int pickerMode) {
+            this.hasModeBeenSet = true;
             this.pickerMode = pickerMode;
+            this.filterMimeTypes = pickerMode == PHOTO_MODE ?
+                new String[] {"image/*"} :
+                new String[] {"video/*"};
             return this;
         }
 

--- a/telegramgallery/src/main/java/com/tangxiaolv/telegramgallery/PhotoAlbumPickerActivity.java
+++ b/telegramgallery/src/main/java/com/tangxiaolv/telegramgallery/PhotoAlbumPickerActivity.java
@@ -70,7 +70,7 @@ public class PhotoAlbumPickerActivity extends BaseFragment
     private boolean sendPressed;
     private boolean singleEntity;
     private boolean allowGifs;
-    private int selectedMode;
+    private @PickerMode int selectedMode;
     private final String[] filterMimeTypes;
 
     private final int[] imageCheckIndexArr;
@@ -118,43 +118,16 @@ public class PhotoAlbumPickerActivity extends BaseFragment
     public View createView(Context context) {
         actionBar.setBackgroundColor(Theme.ACTION_BAR_MEDIA_PICKER_COLOR);
         actionBar.setItemsBackgroundColor(Theme.ACTION_BAR_PICKER_SELECTOR_COLOR);
-        // actionBar.setBackButtonImage(R.drawable.ic_ab_back);
         actionBar.setBackText(context.getString(R.string.Cancel));
         actionBar.setActionBarMenuOnItemClick(new ActionBar.ActionBarMenuOnItemClick() {
-            @Override
-            public void onItemClick(int id) {
-                if (id == -1) {
-                    finishFragment();
-                } else if (id == 1) {
-                    if (delegate != null) {
-                        finishFragment(false);
-                        delegate.startPhotoSelectActivity();
-                    }
-                } else if (id == item_photos) {
-                    if (selectedMode == 0) {
-                        return;
-                    }
-                    selectedMode = 0;
-                    dropDown.setText(
-                            R.string.PickerPhotos);
-                    emptyView.setText(R.string.NoPhotos);
-                    listAdapter.notifyDataSetChanged();
-                } else if (id == item_video) {
-                    if (selectedMode == 1) {
-                        return;
-                    }
-                    selectedMode = 1;
-                    dropDown.setText(
-                            R.string.PickerVideo);
-                    emptyView.setText(R.string.NoVideo);
-                    listAdapter.notifyDataSetChanged();
-                }
-            }
-        });
-
-
+                                                  @Override
+                                                  public void onItemClick(int id) {
+                                                      if (id == -1) {
+                                                          finishFragment();
+                                                      }
+                                                  }
+                                              });
         fragmentView = new FrameLayout(context);
-
         FrameLayout frameLayout = (FrameLayout) fragmentView;
         frameLayout.setBackgroundColor(DarkTheme ? 0xff000000 : 0xffffffff);
 
@@ -184,7 +157,8 @@ public class PhotoAlbumPickerActivity extends BaseFragment
         emptyView.setTextSize(20);
         emptyView.setGravity(Gravity.CENTER);
         emptyView.setVisibility(View.GONE);
-        final @StringRes int resId = selectedMode == GalleryConfig.PHOTO_MODE ? R.string.NoPhotos : R.string.NoVideo;
+        final @StringRes int resId = selectedMode == GalleryConfig.PHOTO_MODE ?
+            R.string.NoPhotos : R.string.NoVideo;
         emptyView.setText(resId);
         frameLayout.addView(emptyView);
         layoutParams = (FrameLayout.LayoutParams) emptyView.getLayoutParams();
@@ -216,28 +190,6 @@ public class PhotoAlbumPickerActivity extends BaseFragment
         layoutParams.gravity = Gravity.CENTER;
         progressView.setLayoutParams(layoutParams);
 
-        // pickerBottomLayout = new PickerBottomLayout(context);
-        // pickerBottomLayout.cancelButton.setVisibility(singleEntity ? View.GONE : View.VISIBLE);
-        // frameLayout.addView(pickerBottomLayout);
-        // layoutParams = (FrameLayout.LayoutParams) pickerBottomLayout.getLayoutParams();
-        // layoutParams.width = LayoutHelper.MATCH_PARENT;
-        // layoutParams.height = AndroidUtilities.dp(48);
-        // layoutParams.gravity = Gravity.BOTTOM;
-        // pickerBottomLayout.setLayoutParams(layoutParams);
-        // pickerBottomLayout.cancelButton.setOnClickListener(new View.OnClickListener() {
-        // @Override
-        // public void onClick(View view) {
-        // openPreview();
-        // }
-        // });
-        // pickerBottomLayout.doneButton.setOnClickListener(new View.OnClickListener() {
-        // @Override
-        // public void onClick(View view) {
-        // sendSelectedPhotos();
-        // finishFragment();
-        // }
-        // });
-
         ArrayList<MediaController.AlbumEntry> dataSource = getDatasource();
         if (loading && (dataSource == null || dataSource != null && dataSource.isEmpty())) {
             progressView.setVisibility(View.VISIBLE);
@@ -246,9 +198,6 @@ public class PhotoAlbumPickerActivity extends BaseFragment
             progressView.setVisibility(View.GONE);
             listView.setEmptyView(emptyView);
         }
-
-        // pickerBottomLayout.updateSelectedCount(selectedPhotos.size() + selectedWebPhotos.size(),
-        // true);
 
         return fragmentView;
     }


### PR DESCRIPTION
## Dependencies
None

## Purpose
When analyzing the source for release builds, looks like we always default to "NoPhotos" string

## Solution
Upon removing final + @StringRes modifier, the conditional is evaluated at run time instead of compile time

## Test Cases
* Ensure the null state appears fine for vides
* Ensure the null state appears fine for photos

## Gif
![nullstate](https://cloud.githubusercontent.com/assets/1796568/23239350/44f9e758-f92c-11e6-99df-f01b1fc84839.gif)

## Asana
https://app.asana.com/0/32089823340740/274113057341705