### PR TITLE
Move string to resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/telegramgallery/src/main/java/com/tangxiaolv/telegramgallery/PhotoPickerActivity.java
+++ b/telegramgallery/src/main/java/com/tangxiaolv/telegramgallery/PhotoPickerActivity.java
@@ -213,9 +213,11 @@ public class PhotoPickerActivity extends BaseFragment
                     final long videoDurationInMillis = selectedAlbum.photos.get(i).getDuration();
                     final long videoSize = selectedAlbum.photos.get(i).getSize();
                     if (videoDurationInMillis > maxVideoDurationInMillis) {
-                        Toast.makeText(context, "You must select a video with a duration of 30 seconds or less", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(context, R.string.telegramgallery_max_video_duration_error_message,
+                            Toast.LENGTH_SHORT).show();
                     } else if (videoSize > maxVideoSizeInBytes) {
-                        Toast.makeText(context, "You must select a video with a size of 50MB or less", Toast.LENGTH_SHORT).show();
+                        Toast.makeText(context, R.string.telegramgallery_max_video_size_error_message,
+                            Toast.LENGTH_SHORT).show();
                     } else if (delegate.didSelectVideo(selectedAlbum.photos.get(i).path)) {
                         finishFragment();
                     }

--- a/telegramgallery/src/main/res/values/strings.xml
+++ b/telegramgallery/src/main/res/values/strings.xml
@@ -32,5 +32,7 @@
     <string name="Preview">Preview</string>
     <string name="album_read_fail">Failed to read an album, please check permissions</string>
     <string name="done">done</string>
+    <string name="telegramgallery_max_video_size_error_message">Sorry, that video is too large. Please choose a video less than 50 MB.</string>
+    <string name="telegramgallery_max_video_duration_error_message">Sorry, that video is too long. Please choose a video that is 30 seconds or less.</string>
 </resources>
 


### PR DESCRIPTION
- Move hardcoded string to resources.

There are two main reasons why we should never ever have hardcoded strings:
- Internationalization
- For libraries, consumers will be able to override the resources (change copy, layouts, dimensions etc...) without having to rebuild the library itself.